### PR TITLE
correção do bug que não permitia que a aba de imagens atualizasse 

### DIFF
--- a/app/js/mosaico.js
+++ b/app/js/mosaico.js
@@ -1,6 +1,5 @@
 function plotMosaico(divID, width, imagesPerLine, data){
 	div = d3.select("#" + divID);
-	console.log(data);
 
 	imgs = div.selectAll("img").data(data);
 

--- a/app/modules/twitter/controllers/main.js
+++ b/app/modules/twitter/controllers/main.js
@@ -339,6 +339,9 @@ hash.controller('mainMonitor', function ($scope, $http, settings, MetricsTwitter
         case 'Url':
                 $scope.functionUrl();
                 break;
+        case 'Images':
+                $scope.functionImages();
+                break;
     }
   };
 
@@ -475,6 +478,9 @@ hash.controller('mainMonitor', function ($scope, $http, settings, MetricsTwitter
 
   $scope.functionImages = function(){
   $scope.loading('TwitterPosts','str_TwitterUrl');
+  $scope.div = "Images"
+
+  resetMosaico("mosaico")
 
   AnalyticsTwitter.mostRecurringImages(
     {


### PR DESCRIPTION
correção do bug que não permitia que a aba de imagens atualizasse quando mudam os filtros.
Removi um console.log desnecessário.